### PR TITLE
Fix error messages in console

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,7 +217,7 @@
         <script src="./src/other-ui-stuff.js"></script>
         <script src="./src/map.js"></script>
         <script src="./src/osm-integration.js"></script>
-        <script src="./src/pwa-EventListeners.js"></script>
+        <script src="./src/pwa-EventListeners.js" type="module"></script>
 
         <!-- Cloudflare Web Analytics -->
         <script defer src='https://static.cloudflareinsights.com/beacon.min.js'

--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -25,7 +25,9 @@ self.addEventListener('fetch', (event) => {
             caches.match(event.request).then((resp) => {
             return resp || fetch(event.request).then((response) => {
                 return caches.open(cacheName).then((cache) => {
-                cache.put(event.request, response.clone());
+                 if(event.request.method == 'GET') {
+                  cache.put(event.request, response.clone());
+                 }
                 return response;
                 });
             });


### PR DESCRIPTION
Two fixes:
* `Uncaught SyntaxError: Unexpected token 'export'`
* `Failed to execute 'put' on 'Cache': Request method 'POST' is unsupported`