### PR TITLE
Use preferred tile.openstreetmap.org URL

### DIFF
--- a/web/map_style/style.json
+++ b/web/map_style/style.json
@@ -9,9 +9,7 @@
     "raster-tiles": {
       "type": "raster",
       "tiles": [
-        "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
-        "https://b.tile.openstreetmap.org/{z}/{x}/{y}.png",
-        "https://c.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
       ],
       "tileSize": 256,
       "maxzoom": 19,


### PR DESCRIPTION
I would like to suggest using the now preferred https://tile.openstreetmap.org URL instead of the current one, see

https://github.com/openstreetmap/operations/issues/737

cc: @starsep 